### PR TITLE
Added required functions for define_restore_log_rules*

### DIFF
--- a/moodle2x/bigbluebuttonbn/backup/moodle2/restore_bigbluebuttonbn_activity_task.class.php
+++ b/moodle2x/bigbluebuttonbn/backup/moodle2/restore_bigbluebuttonbn_activity_task.class.php
@@ -64,4 +64,22 @@ class restore_bigbluebuttonbn_activity_task extends restore_activity_task {
     static public function define_decode_rules() {
         return array();
     }
+
+    static public function define_restore_log_rules() {
+        $rules = array();
+
+        $rules[] = new restore_log_rule('bigbluebuttonbn', 'add', 'view.php?id={course_module}', '{bigbluebuttonbn}');
+        $rules[] = new restore_log_rule('bigbluebuttonbn', 'update', 'view.php?id={course_module}', '{bigbluebuttonbn}');
+        $rules[] = new restore_log_rule('bigbluebuttonbn', 'view', 'view.php?id={course_module}', '{bigbluebuttonbn}');
+
+        return $rules;
+    }
+
+    static public function define_restore_log_rules_for_course() {
+        $rules = array();
+
+        $rules[] = new restore_log_rule('bigbluebuttonbn', 'view all', 'index.php?id={course}', null);
+
+        return $rules;
+    }
 }

--- a/moodle2x/recordingsbn/backup/moodle2/restore_recordingsbn_activity_task.class.php
+++ b/moodle2x/recordingsbn/backup/moodle2/restore_recordingsbn_activity_task.class.php
@@ -64,4 +64,23 @@ class restore_recordingsbn_activity_task extends restore_activity_task {
     static public function define_decode_rules() {
         return array();
     }
+
+    static public function define_restore_log_rules() {
+        $rules = array();
+
+        $rules[] = new restore_log_rule('recordingsbn', 'add', 'view.php?id={course_module}', '{recordingsbn}');
+        $rules[] = new restore_log_rule('recordingsbn', 'update', 'view.php?id={course_module}', '{recordingsbn}');
+        $rules[] = new restore_log_rule('recordingsbn', 'view', 'view.php?id={course_module}', '{recordingsbn}');
+
+        return $rules;
+    }
+
+    static public function define_restore_log_rules_for_course() {
+        $rules = array();
+
+        $rules[] = new restore_log_rule('recordingsbn', 'view all', 'index.php?id={course}', null);
+
+        return $rules;
+    }
+
 }


### PR DESCRIPTION
I've added a couple of required functions to restore_bigbluebuttonbn_activity_task.class.php.  This allows backup/restore of activities to be performed without error.
